### PR TITLE
update dependencies

### DIFF
--- a/lib/src/algorithms/rsa.dart
+++ b/lib/src/algorithms/rsa.dart
@@ -253,8 +253,11 @@ class RSAKeyParser {
   }
 }
 
-Uint8List _hexToBytes(String encoded) => Uint8List.fromList(List.generate(
-        encoded.length, (i) => i % 2 == 0 ? encoded.substring(i, i + 2) : null)
-    .where((b) => b != null)
-    .map((b) => int.parse(b, radix: 16))
-    .toList());
+Uint8List _hexToBytes(String encoded) => (
+  Uint8List.fromList(
+    List.generate(encoded.length, (i) => i % 2 == 0 ? encoded.substring(i, i + 2) : null)
+      .where((b) => b != null)
+      .map((b) => int.parse(b, radix: 16))
+      .toList()
+  )
+);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,14 +21,14 @@ packages:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.2"
+    version: "1.6.0"
   asn1lib:
     dependency: "direct main"
     description:
       name: asn1lib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.15"
+    version: "0.6.4"
   async:
     dependency: transitive
     description:
@@ -77,7 +77,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.3+3"
+    version: "0.13.9"
   crypto:
     dependency: "direct main"
     description:
@@ -203,7 +203,7 @@ packages:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.9.3"
   package_resolver:
     dependency: transitive
     description:
@@ -280,7 +280,7 @@ packages:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.5"
+    version: "2.0.0"
   source_maps:
     dependency: transitive
     description:
@@ -329,21 +329,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.4"
+    version: "1.14.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.11"
+    version: "0.2.15"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.3.4"
   typed_data:
     dependency: transitive
     description:
@@ -372,6 +372,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  webkit_inspection_protocol:
+    dependency: transitive
+    description:
+      name: webkit_inspection_protocol
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.2"
   yaml:
     dependency: transitive
     description:
@@ -380,4 +387,4 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=2.3.0 <3.0.0"
+  dart: ">=2.7.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: encrypt
-version: 4.0.0
+version: 4.0.1
 description: A set of high-level APIs over PointyCastle for two-way cryptography.
 author: leocavalcante <lc@leocavalcante.com>
 homepage: https://github.com/leocavalcante/encrypt
@@ -11,12 +11,12 @@ environment:
   sdk: ">=2.2.2 <3.0.0"
 
 dependencies:
-  args: ^1.5.2
-  asn1lib: ^0.5.8
+  args: ^1.6.0
+  asn1lib: ^0.6.4
   clock: ^1.0.1
-  collection: ^1.14.11
-  crypto: ^2.1.2
-  pointycastle: ^1.0.1
+  collection: ^1.14.12
+  crypto: ^2.1.4
+  pointycastle: ^1.0.2
 
 dev_dependencies:
-  test: ^1.6.4
+  test: ^1.14.3


### PR DESCRIPTION
Because corsac_jwt >=0.2.2 depends on asn1lib ^0.6.4 and encrypt 4.0.0 depends on asn1lib ^0.5.8, corsac_jwt >=0.2.2 is incompatible with encrypt 4.0.0.