### PR TITLE
Add parseKeyFromFileSync() method

### DIFF
--- a/lib/encrypt_io.dart
+++ b/lib/encrypt_io.dart
@@ -9,3 +9,10 @@ Future<T> parseKeyFromFile<T extends RSAAsymmetricKey>(String filename) async {
   final parser = RSAKeyParser();
   return parser.parse(key) as T;
 }
+
+T parseKeyFromFileSync<T extends RSAAsymmetricKey>(String filename) {
+  final file = File(filename);
+  final key = await file.readAsStringSync();
+  final parser = RSAKeyParser();
+  return parser.parse(key) as T;
+}


### PR DESCRIPTION
The library was missing a `parseKeyFromFileSync()` method for non-async execution scenarios, such as for use in a constructor.
