### PR TITLE
Remove accidental inclusion of await

### DIFF
--- a/lib/encrypt_io.dart
+++ b/lib/encrypt_io.dart
@@ -12,7 +12,7 @@ Future<T> parseKeyFromFile<T extends RSAAsymmetricKey>(String filename) async {
 
 T parseKeyFromFileSync<T extends RSAAsymmetricKey>(String filename) {
   final file = File(filename);
-  final key = await file.readAsStringSync();
+  final key = file.readAsStringSync();
   final parser = RSAKeyParser();
   return parser.parse(key) as T;
 }


### PR DESCRIPTION
Introduced in PR #243. `file.readAsStringSync()` does not require await.

Signed-off-by: Dani Llewellyn <diddledani@ubuntu.com>