### PR TITLE
fix to allow fernet for work for dart2js

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ void main() {
   final plainText = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit';
   final key = Key.fromUtf8('my32lengthsupersecretnooneknows1');
 
-  final b64key = Key.fromUtf8(base64Url.encode(key.bytes));
+  final b64key = Key.fromUtf8(base64Url.encode(key.bytes).substring(0,32));
   // if you need to use the ttl feature, you'll need to use APIs in the algorithm itself
   final fernet = Fernet(b64key);
   final encrypter = Encrypter(fernet);

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ final encrypter = Encrypter(AES(key, mode: AESMode.cbc));
 - OFB-64 `AESMode.ofb64`
 - SIC `AESMode.sic`
 
-##### No/zero padding 
+##### No/zero padding
 
 To remove padding, pass `null` to the `padding` named parameter on the constructor:
 
@@ -128,7 +128,6 @@ import 'dart:convert';
 void main() {
   final plainText = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit';
   final key = Key.fromUtf8('my32lengthsupersecretnooneknows1');
-  final iv = IV.fromLength(16);
 
   final b64key = Key.fromUtf8(base64Url.encode(key.bytes));
   // if you need to use the ttl feature, you'll need to use APIs in the algorithm itself

--- a/lib/src/algorithms/fernet.dart
+++ b/lib/src/algorithms/fernet.dart
@@ -73,11 +73,12 @@ class Fernet implements Algorithm {
       // in dart2js there is no getUint64(), so fall back and improvise.
       //  Note this is not perfect as dart2js only has doubles, no 64bit ints,
       //  but this is only going to be compared to a .now().millisecondsSinceEpoch
-      //  timestamp in and int so we don't need to worry about being >max int
-      //  we can store because .now().millisecondsSinceEpoch would have the same
+      //  timestamp in and int so we don't need to worry about being
+      //  larger than max int (of js double) we can store because
+      //  .now().millisecondsSinceEpoch would have the same
       //  overloading problem -we'll all be dead when it overflows
-      //  (max double/millseconds in year =9007199254740991/3.154e+10=285580 years
-      //   from 1970)
+      //  (max int of double/millseconds in year
+      //   =9007199254740991 / 3.154e+10 = 285580 years from 1970)
       final int hi=bdata.getUint32(0, Endian.big);
       final int low=bdata.getUint32(4, Endian.big);
       return (hi<<32|low);

--- a/lib/src/algorithms/fernet.dart
+++ b/lib/src/algorithms/fernet.dart
@@ -69,7 +69,7 @@ class Fernet implements Algorithm {
     var bdata = ByteData.view(buffer);
     try {
       return bdata.getUint64(0, Endian.big);
-    } catch (e) {
+    } catch (_) {
       // in dart2js there is no getUint64(), so fall back and improvise.
       //  Note this is not perfect as dart2js only has doubles, no 64bit ints,
       //  but this is only going to be compared to a .now().millisecondsSinceEpoch
@@ -102,7 +102,15 @@ class Fernet implements Algorithm {
     // convert epoch timestamp to binary data, in bytes
     var buffer = Uint8List(8).buffer;
     var bdata = ByteData.view(buffer);
-    bdata.setUint64(0, currentTime, Endian.big);
+    try {
+      bdata.setUint64(0, currentTime, Endian.big);
+    } catch (_) {
+      // in dart2js there is no setUint64(), so fall back and improvise.
+      final int hi=(currentTime>>32)&0xffffffff;
+      final int low=currentTime&0xffffffff;
+      bdata.setUint32(0, hi, Endian.big);
+      bdata.setUint32(4, low, Endian.big);
+    }
     final currentTimeBytes = bdata.buffer.asUint8List();
 
     final parts = [0x80, ...currentTimeBytes, ...iv.bytes, ...cipherText.bytes];

--- a/lib/src/algorithms/fernet.dart
+++ b/lib/src/algorithms/fernet.dart
@@ -67,7 +67,21 @@ class Fernet implements Algorithm {
     final tsBytes = data.sublist(1, 9);
     var buffer = Uint8List.fromList(tsBytes).buffer;
     var bdata = ByteData.view(buffer);
-    return bdata.getUint64(0, Endian.big);
+    try {
+      return bdata.getUint64(0, Endian.big);
+    } catch (e) {
+      // in dart2js there is no getUint64(), so fall back and improvise.
+      //  Note this is not perfect as dart2js only has doubles, no 64bit ints,
+      //  but this is only going to be compared to a .now().millisecondsSinceEpoch
+      //  timestamp in and int so we don't need to worry about being >max int
+      //  we can store because .now().millisecondsSinceEpoch would have the same
+      //  overloading problem -we'll all be dead when it overflows
+      //  (max double/millseconds in year =9007199254740991/3.154e+10=285580 years
+      //   from 1970)
+      final int hi=bdata.getUint32(0, Endian.big);
+      final int low=bdata.getUint32(4, Endian.big);
+      return (hi<<32|low);
+    }
   }
 
   void _verifySignature(Uint8List data) {


### PR DESCRIPTION
This PR fixes the fernet algorithm work (and to no longer throw exceptions 'Uint64 accessor not supported by dart2js' on dart2js platforms.) (As first mentioned by @steinmetz and @phuchuynhStrong in #184)

I tested this to verify that the fix allows the encryption/decryption to interoperate between dart vm and dart2js environments.

I also encountered this error when passing things between server and web, so I thought I would rectify it.

I also clarified the fernet readme.md example.  I removed the unused, and irrelevant IV variable, and I added a .substring(0,32) when making the key for fernet.  This prevents the exception mentioned in #184 and also make the example work correctly.
IMHO this also clarifies to users that the key must be exactly 32 bytes long (as well as guaranteeing that).