### PR TITLE
fix: export RSAAsymmetricKeys api

### DIFF
--- a/lib/encrypt_io.dart
+++ b/lib/encrypt_io.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:encrypt/encrypt.dart';
 import 'package:pointycastle/asymmetric/api.dart';
+export 'package:pointycastle/asymmetric/api.dart';
 
 Future<T> parseKeyFromFile<T extends RSAAsymmetricKey>(String filename) async {
   final file = File(filename);


### PR DESCRIPTION
When trying to parse a `.pem`, we need the `RSAPrivateKey` and `RSAPublicKey`, but this model is not being exported outside of the lib.

This fix the linter: https://dart-lang.github.io/linter/lints/depend_on_referenced_packages.html

closes: #227, #125, #115, #93, #125