### PR TITLE
update dart sdk to support >=2.18.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,15 +7,15 @@ executables:
   secure-random:
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
-  args: ^2.0.0
-  asn1lib: ^1.0.0
-  clock: ^1.1.0
-  collection: ^1.15.0
-  crypto: ^3.0.0
-  pointycastle: ^3.5.0
+  args: ^2.3.1
+  asn1lib: ^1.4.0
+  clock: ^1.1.1
+  collection: ^1.17.0
+  crypto: ^3.0.2
+  pointycastle: ^3.6.2
 
 dev_dependencies:
-  test: ^1.16.8
+  test: ^1.22.0


### PR DESCRIPTION
This PR upgrade dart sdk version to support min dart sdk >=2.18