### PR TITLE
fix: Could not parse version "~3.6.2"

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   clock: ^1.1.1
   collection: ^1.17.0
   crypto: ^3.0.2
-  pointycastle: ~3.6.2
+  pointycastle: ^3.6.2
 
 dev_dependencies:
   lints: ^2.0.0


### PR DESCRIPTION
pub get fails because version "~3.6.2" cannot be resolved